### PR TITLE
Set client version string while calling fetch_game_record

### DIFF
--- a/example.py
+++ b/example.py
@@ -128,6 +128,7 @@ async def load_and_process_game_log(lobby, uuid):
 
     req = pb.ReqGameRecord()
     req.game_uuid = uuid
+    req.client_version_string = 'web-0.9.205'
     res = await lobby.fetch_game_record(req)
 
     record_wrapper = pb.Wrapper()


### PR DESCRIPTION
example.py had a failing call to fetch_game_record because the new client_version_string field was not being set. 

Resolves: #5 